### PR TITLE
Remove reference to hetzner provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![](https://img.shields.io/github/license/G-Core/external-dns-gcore-webhook?style=for-the-badge)](LICENSE)
 
-ExternalDNS is a Kubernetes add-on for automatically managing Domain Name System (DNS) records for Kubernetes services by using different DNS providers. By default, Kubernetes manages DNS records internally, but ExternalDNS takes this functionality a step further by delegating the management of DNS records to an external DNS provider such as this one. Therefore, the Hetzner webhook allows to manage your Hetzner domains inside your kubernetes cluster with [ExternalDNS](//github.com/kubernetes-sigs/external-dns).
+ExternalDNS is a Kubernetes add-on for automatically managing Domain Name System (DNS) records for Kubernetes services by using different DNS providers. By default, Kubernetes manages DNS records internally, but ExternalDNS takes this functionality a step further by delegating the management of DNS records to an external DNS provider such as this one. Therefore, the Gcore webhook allows to manage your Gcore domains inside your kubernetes cluster with [ExternalDNS](//github.com/kubernetes-sigs/external-dns).
 
 To use ExternalDNS with Gcore you need to get API token from https://accounts.gcore.com/profile/api-tokens.
 


### PR DESCRIPTION
Hi, I'm the maintainer of external DNS. I was looking at the list of supported webhook and clicked on this one and saw that there were some wrong references to Hetzner in the README. I thought I would just provide a pull request to change those, feel free to disregard this if you don't want to merge this. Also okay if you prefer to do it yourself. 