### PR TITLE
restore normal TXT record handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,20 @@ ExternalDNS is a Kubernetes add-on for automatically managing Domain Name System
 
 To use ExternalDNS with Gcore you need to get API token from https://accounts.gcore.com/profile/api-tokens.
 
-Note as per `v0.1.0` TXT record will no longer be created as workaround for wildcard record.
+As of `v0.1.7`, the webhook no longer skips TXT records and handles them normally.
+For wildcard hosts, use the `--txt-wildcard-replacement` option on the `external-dns` container:
+
+```yaml
+      containers:
+        - name: external-dns
+          image: registry.k8s.io/external-dns/external-dns:v0.20.0
+          args:
+            - --source=service
+            - --source=ingress
+            - --provider=webhook
+            - --txt-owner-id=my-owner
+            - --txt-wildcard-replacement=wildcard
+```
 
 ## Deployment in kubernetes:
 

--- a/gcoreprovider/gcore.go
+++ b/gcoreprovider/gcore.go
@@ -202,7 +202,7 @@ func (p *DnsProvider) ApplyChanges(rootCtx context.Context, changes *plan.Change
 	for _, c := range changes.Create {
 		c := c
 		zone := extractZone(c.DNSName)
-		if zone == "" || (c.RecordType == "TXT") { //{ && strings.Index(c.DNSName, `*`) > 0) {
+		if zone == "" {
 			continue
 		}
 		recordValues := make([]gdns.ResourceRecord, 0)
@@ -292,16 +292,7 @@ func (p *DnsProvider) GetDomainFilter() endpoint.DomainFilter {
 }
 
 func (p *DnsProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
-	adjusted := make([]*endpoint.Endpoint, 0, len(endpoints))
-	for _, e := range endpoints {
-		e := e
-		if e.RecordType != "TXT" { // || // normal A/AAAA
-			//strings.Index(e.DNSName, `*`) <= 0 { // as long as * not in the middle
-			adjusted = append(adjusted, e)
-		}
-	}
-	return adjusted, nil
-	//return endpoints, nil
+	return endpoints, nil
 }
 
 func (p *DnsProvider) PropertyValuesEqual(_ string, previous string, current string) bool {

--- a/gcoreprovider/gcore_test.go
+++ b/gcoreprovider/gcore_test.go
@@ -378,6 +378,40 @@ func Test_dnsProvider_ApplyChanges(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "create TXT ok",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters []string) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					addZoneRRSet: func(ctx context.Context, zone, recordName, recordType string, values []gdns.ResourceRecord, ttl int) error {
+						if zone == "test.com" &&
+							ttl == 10 &&
+							recordName == "my.test.com" &&
+							recordType == "TXT" &&
+							values[0].Content[0] == "\"heritage=external-dns,external-dns/owner=default\"" {
+							return nil
+						}
+						return fmt.Errorf("addZoneRRSet wrong params: zone=%s name=%s type=%s values=%+v ttl=%d",
+							zone, recordName, recordType, values, ttl)
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Create: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+							"\"heritage=external-dns,external-dns/owner=default\""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "update ok",
 			fields: fields{
 				domainFilter: endpoint.DomainFilter{},
@@ -431,6 +465,57 @@ func Test_dnsProvider_ApplyChanges(t *testing.T) {
 			}
 			if err := p.ApplyChanges(tt.args.ctx, tt.args.changes); (err != nil) != tt.wantErr {
 				t.Errorf("ApplyChanges() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_dnsProvider_AdjustEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []*endpoint.Endpoint
+		want []*endpoint.Endpoint
+	}{
+		{
+			name: "mixed types preserved",
+			in: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("my.test.com", "A", 10, "1.1.1.1"),
+				endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+					"\"heritage=external-dns,external-dns/owner=default\""),
+			},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("my.test.com", "A", 10, "1.1.1.1"),
+				endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+					"\"heritage=external-dns,external-dns/owner=default\""),
+			},
+		},
+		{
+			name: "txt only",
+			in: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+					"\"heritage=external-dns,external-dns/owner=default\""),
+			},
+			want: []*endpoint.Endpoint{
+				endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+					"\"heritage=external-dns,external-dns/owner=default\""),
+			},
+		},
+		{
+			name: "empty",
+			in:   []*endpoint.Endpoint{},
+			want: []*endpoint.Endpoint{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &DnsProvider{}
+			got, err := p.AdjustEndpoints(tt.in)
+			if err != nil {
+				t.Errorf("AdjustEndpoints() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AdjustEndpoints() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
  ## Summary

  - Reverts TXT record skipping introduced in commits 5d8f409, b7301eb, fbe7644
  - TXT records are now created and returned through `AdjustEndpoints` like any other record type
  - Removes outdated README note about TXT skip; adds v0.1.7 note with `--txt-wildcard-replacement` guidance
  - Adds tests for TXT record creation and `AdjustEndpoints` pass-through

  ## Background

  Earlier commits progressively added TXT filtering as a workaround for wildcard record conflicts. This is better handled by external-dns itself via `--txt-wildcard-replacement`.

  ## Test plan

  - [x] `go build ./...` passes
  - [x] `go test ./...` passes (14/14 including 2 new TXT-specific tests)