### PR TITLE
DNS-3025 fix ownership txt records handling

### DIFF
--- a/gcoreprovider/gcore.go
+++ b/gcoreprovider/gcore.go
@@ -111,6 +111,11 @@ func (p *DnsProvider) Records(rootCtx context.Context) ([]*endpoint.Endpoint, er
 				skipped++
 				continue
 			}
+			for i, answer := range r.ShortAnswers {
+				if r.Type == endpoint.RecordTypeTXT {
+					r.ShortAnswers[i] = escapeOwnershipTXTRecordValue(answer)
+				}
+			}
 			result = append(result,
 				endpoint.NewEndpointWithTTL(r.Name, r.Type, endpoint.TTL(r.TTL), r.ShortAnswers...))
 		}
@@ -155,7 +160,7 @@ func (p *DnsProvider) ApplyChanges(rootCtx context.Context, changes *plan.Change
 				continue
 			}
 			log.Debug(msg)
-			recordValues = append(recordValues, content)
+			recordValues = append(recordValues, unescapeOwnershipTXTRecordValue(content))
 			errMsg = append(errMsg, msg)
 		}
 		if len(recordValues) == 0 {
@@ -187,7 +192,7 @@ func (p *DnsProvider) ApplyChanges(rootCtx context.Context, changes *plan.Change
 				continue
 			}
 			log.Debug(msg)
-			recordValues = append(recordValues, content)
+			recordValues = append(recordValues, unescapeOwnershipTXTRecordValue(content))
 			errMsg = append(errMsg, msg)
 		}
 		gr1.Go(func() error {
@@ -216,7 +221,7 @@ func (p *DnsProvider) ApplyChanges(rootCtx context.Context, changes *plan.Change
 			}
 			log.Debug(msg)
 			rr := gdns.ResourceRecord{Enabled: true}
-			rr.SetContent(c.RecordType, content)
+			rr.SetContent(c.RecordType, unescapeOwnershipTXTRecordValue(content))
 			recordValues = append(recordValues, rr)
 			errMsg = append(errMsg, msg)
 		}
@@ -252,7 +257,7 @@ func (p *DnsProvider) ApplyChanges(rootCtx context.Context, changes *plan.Change
 			}
 			log.Debug(msg)
 			rr := gdns.ResourceRecord{Enabled: true}
-			rr.SetContent(c.RecordType, content)
+			rr.SetContent(c.RecordType, unescapeOwnershipTXTRecordValue(content))
 			recordValues = append(recordValues, rr)
 			errMsg = append(errMsg, msg)
 		}
@@ -399,4 +404,18 @@ type EnvError string
 
 func (e EnvError) Error() string {
 	return fmt.Sprintf("invalid environment var: %s", string(e))
+}
+
+func escapeOwnershipTXTRecordValue(value string) string {
+	if strings.HasPrefix(value, "heritage=") {
+		return fmt.Sprintf("\"%s\"", value)
+	}
+	return value
+}
+
+func unescapeOwnershipTXTRecordValue(value string) string {
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") && strings.HasPrefix(value, "\"heritage=") {
+		return value[1 : len(value)-1]
+	}
+	return value
 }

--- a/gcoreprovider/gcore.go
+++ b/gcoreprovider/gcore.go
@@ -111,8 +111,8 @@ func (p *DnsProvider) Records(rootCtx context.Context) ([]*endpoint.Endpoint, er
 				skipped++
 				continue
 			}
-			for i, answer := range r.ShortAnswers {
-				if r.Type == endpoint.RecordTypeTXT {
+			if r.Type == endpoint.RecordTypeTXT {
+				for i, answer := range r.ShortAnswers {
 					r.ShortAnswers[i] = escapeOwnershipTXTRecordValue(answer)
 				}
 			}

--- a/gcoreprovider/gcore_test.go
+++ b/gcoreprovider/gcore_test.go
@@ -142,6 +142,111 @@ func Test_dnsProvider_Records(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "txt heritage wrapped on read",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters []string) ([]gdns.Zone, error) {
+						return []gdns.Zone{
+							{
+								Name: "example.com",
+								Records: []gdns.ZoneRecord{
+									{
+										Name:         "test.example.com",
+										Type:         "TXT",
+										TTL:          10,
+										ShortAnswers: []string{"heritage=external-dns,external-dns/owner=default"},
+									},
+								},
+							},
+						}, nil
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []endpoint.Endpoint{
+				*endpoint.NewEndpointWithTTL(
+					"test.example.com", "TXT", endpoint.TTL(10),
+					"\"heritage=external-dns,external-dns/owner=default\""),
+			},
+			wantErr: false,
+		},
+		{
+			name: "txt non-heritage untouched on read",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters []string) ([]gdns.Zone, error) {
+						return []gdns.Zone{
+							{
+								Name: "example.com",
+								Records: []gdns.ZoneRecord{
+									{
+										Name:         "test.example.com",
+										Type:         "TXT",
+										TTL:          10,
+										ShortAnswers: []string{"v=spf1 ~all"},
+									},
+								},
+							},
+						}, nil
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []endpoint.Endpoint{
+				*endpoint.NewEndpointWithTTL(
+					"test.example.com", "TXT", endpoint.TTL(10), "v=spf1 ~all"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "txt heritage multiple values wrapped",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters []string) ([]gdns.Zone, error) {
+						return []gdns.Zone{
+							{
+								Name: "example.com",
+								Records: []gdns.ZoneRecord{
+									{
+										Name: "test.example.com",
+										Type: "TXT",
+										TTL:  10,
+										ShortAnswers: []string{
+											"heritage=external-dns,external-dns/owner=a",
+											"heritage=external-dns,external-dns/owner=b",
+										},
+									},
+								},
+							},
+						}, nil
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: []endpoint.Endpoint{
+				*endpoint.NewEndpointWithTTL(
+					"test.example.com", "TXT", endpoint.TTL(10),
+					"\"heritage=external-dns,external-dns/owner=a\"",
+					"\"heritage=external-dns,external-dns/owner=b\""),
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -391,7 +496,7 @@ func Test_dnsProvider_ApplyChanges(t *testing.T) {
 							ttl == 10 &&
 							recordName == "my.test.com" &&
 							recordType == "TXT" &&
-							values[0].Content[0] == "\"heritage=external-dns,external-dns/owner=default\"" {
+							values[0].Content[0] == "heritage=external-dns,external-dns/owner=default" {
 							return nil
 						}
 						return fmt.Errorf("addZoneRRSet wrong params: zone=%s name=%s type=%s values=%+v ttl=%d",
@@ -406,6 +511,84 @@ func Test_dnsProvider_ApplyChanges(t *testing.T) {
 					Create: []*endpoint.Endpoint{
 						endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
 							"\"heritage=external-dns,external-dns/owner=default\""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete TXT heritage unquoted",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters []string) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					deleteRRSetRecord: func(ctx context.Context, zone, name, recordType string, contents ...string) error {
+						if zone == "test.com" && name == "my.test.com" && recordType == "TXT" &&
+							len(contents) == 1 &&
+							contents[0] == "heritage=external-dns,external-dns/owner=default" {
+							return nil
+						}
+						return fmt.Errorf("deleteRRSetRecord wrong params: zone=%s name=%s type=%s contents=%+v",
+							zone, name, recordType, contents)
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					Delete: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+							"\"heritage=external-dns,external-dns/owner=default\""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "update TXT heritage round-trip",
+			fields: fields{
+				domainFilter: endpoint.DomainFilter{},
+				client: dnsManagerMock{
+					zonesWithRecords: func(ctx context.Context,
+						filters []string) ([]gdns.Zone, error) {
+						return []gdns.Zone{{Name: "test.com"}}, nil
+					},
+					deleteRRSetRecord: func(ctx context.Context, zone, name, recordType string, contents ...string) error {
+						if zone == "test.com" && name == "my.test.com" && recordType == "TXT" &&
+							len(contents) == 1 &&
+							contents[0] == "heritage=external-dns,external-dns/owner=default" {
+							return nil
+						}
+						return fmt.Errorf("deleteRRSetRecord wrong params: zone=%s name=%s type=%s contents=%+v",
+							zone, name, recordType, contents)
+					},
+					addZoneRRSet: func(ctx context.Context, zone, recordName, recordType string, values []gdns.ResourceRecord, ttl int) error {
+						if zone == "test.com" && ttl == 10 &&
+							recordName == "my.test.com" && recordType == "TXT" &&
+							len(values) == 1 &&
+							values[0].Content[0] == "heritage=external-dns,external-dns/owner=new" {
+							return nil
+						}
+						return fmt.Errorf("addZoneRRSet wrong params: zone=%s name=%s type=%s values=%+v ttl=%d",
+							zone, recordName, recordType, values, ttl)
+					},
+				},
+				dryRun: false,
+			},
+			args: args{
+				ctx: context.Background(),
+				changes: &plan.Changes{
+					UpdateOld: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+							"\"heritage=external-dns,external-dns/owner=default\""),
+					},
+					UpdateNew: []*endpoint.Endpoint{
+						endpoint.NewEndpointWithTTL("my.test.com", "TXT", 10,
+							"\"heritage=external-dns,external-dns/owner=new\""),
 					},
 				},
 			},
@@ -611,6 +794,98 @@ func TestNonExistingTargets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := unexistingTargets(tt.args.existing, tt.args.toCompare, tt.args.diffFromExisting); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("unexistingTargets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_escapeOwnershipTXTRecordValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "heritage wrapped",
+			in:   "heritage=external-dns,external-dns/owner=default",
+			want: "\"heritage=external-dns,external-dns/owner=default\"",
+		},
+		{
+			name: "non-heritage TXT untouched",
+			in:   "v=spf1 include:_spf.example.com ~all",
+			want: "v=spf1 include:_spf.example.com ~all",
+		},
+		{
+			name: "empty untouched",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "already-quoted heritage stays single-quoted",
+			in:   "\"heritage=foo\"",
+			want: "\"heritage=foo\"",
+		},
+		{
+			name: "heritage not at start untouched",
+			in:   "x heritage=foo",
+			want: "x heritage=foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeOwnershipTXTRecordValue(tt.in); got != tt.want {
+				t.Errorf("escapeOwnershipTXTRecordValue(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_unescapeOwnershipTXTRecordValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "quoted heritage unwrapped",
+			in:   "\"heritage=external-dns,external-dns/owner=default\"",
+			want: "heritage=external-dns,external-dns/owner=default",
+		},
+		{
+			name: "unquoted heritage untouched",
+			in:   "heritage=external-dns,external-dns/owner=default",
+			want: "heritage=external-dns,external-dns/owner=default",
+		},
+		{
+			name: "quoted non-heritage untouched",
+			in:   "\"v=spf1 ~all\"",
+			want: "\"v=spf1 ~all\"",
+		},
+		{
+			name: "empty untouched",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "lone quote untouched",
+			in:   "\"",
+			want: "\"",
+		},
+		{
+			name: "opening quote only untouched",
+			in:   "\"heritage=foo",
+			want: "\"heritage=foo",
+		},
+		{
+			name: "closing quote only untouched",
+			in:   "heritage=foo\"",
+			want: "heritage=foo\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unescapeOwnershipTXTRecordValue(tt.in); got != tt.want {
+				t.Errorf("unescapeOwnershipTXTRecordValue(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
  Two systems disagree on how TXT content is represented:

  | Component | Form of an ownership TXT value |
  |---|---|
  | **external-dns** registry | quoted zone-file form: `"heritage=external-dns,…"` |
  | **Gcore DNS API** | raw payload: `heritage=external-dns,…` |

  Additional constraint: the **Gcore DNS SDK cannot correctly compare quoted strings for equality**. Any SDK operation that identifies a record by its content (delete-by-value, update diff) silently fails to
  match when the value contains `"`.

  ### Consequence

  Passing external-dns's quoted `"heritage=…"` straight through to Gcore caused two failures:

  1. Gcore stored the quotes as literal payload characters, so the next read returned a doubly-quoted value.
  2. Even before that, SDK-level equality checks couldn't match quoted content, so deletes and update diffs didn't resolve the right record.

  Meanwhile, a raw `heritage=…` coming back from `Records()` didn't match what external-dns expected in its registry — so it saw a permanent diff and churned on every reconcile. Because the ownership marker
  never stabilised, external-dns lost track of the records it owned, and managed A/CNAME records flapped.

  ### Fix

  Translate only at the provider boundary, and only for values that look like ownership markers (`heritage=…`). Regular user TXT records (SPF, DKIM, verification tokens) still pass through verbatim — the
  behaviour restored in `73b3b3c` is preserved.

  Two helpers in `gcoreprovider/gcore.go`:

  - `escapeOwnershipTXTRecordValue` — wraps the value in `"…"` iff it starts with `heritage=`.
  - `unescapeOwnershipTXTRecordValue` — strips surrounding quotes iff the value is `"heritage=…"`.

  Wired in:

  - **Read** (`Records`) — wrap heritage answers before handing them to external-dns, so its registry sees the expected quoted form.
  - **Write** (`ApplyChanges`) — strip quotes at all four call sites (update-old delete, delete, create, update-new add) before passing to the Gcore SDK, so the SDK only ever sees raw, comparable content.

  ### Result

  - Ownership TXTs round-trip correctly between external-dns and Gcore.
  - The Gcore SDK's quoted-equality limitation is sidestepped — it never sees quotes.
  - external-dns's registry matches on every reconcile; no more churn or ownership loss.
  - Regular TXT record handling is unchanged.